### PR TITLE
Update jasmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Check out the [Getting Started](http://facebook.github.io/jest/docs/getting-star
   - [`config.testPathDirs` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-testpathdirs-array-string)
   - [`config.testPathIgnorePatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-testpathignorepatterns-array-string)
   - [`config.testPathPattern` [string]](http://facebook.github.io/jest/docs/api.html#config-testpathpattern-string)
+  - [`config.testRunner` [string]](http://facebook.github.io/jest/docs/api.html#config-testrunner-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-unmockedmodulepathpatterns-array-string)
 
 #### Globally injected variables

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,7 @@ permalink: docs/api.html
   - [`config.testPathDirs` [array<string>]](#config-testpathdirs-array-string)
   - [`config.testPathIgnorePatterns` [array<string>]](#config-testpathignorepatterns-array-string)
   - [`config.testPathPattern` [string]](http://facebook.github.io/jest/docs/api.html#config-testpathpattern-string)
+  - [`config.testRunner` [string]](http://facebook.github.io/jest/docs/api.html#config-testrunner-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](#config-unmockedmodulepathpatterns-array-string)
 
 #### Globally injected variables
@@ -353,6 +354,11 @@ An array of regexp pattern strings that are matched against all test paths befor
 A regexp pattern string that is matched against all test paths before executing the test. If the test path does not match the pattern, it will be skipped.
 
 This is useful if you need to override the default. If you are testing one file at a time the default will be set to `/.*/`, however if you pass a blob rather than a single file the default will then be the absolute path of each test file. The override may be needed on windows machines where, for example, the test full path would be `C:/myproject/__tests__/mystest.jsx.jest` and the default pattern would be set as `/C:\myproject\__tests__\mystest.jsx.jest/`.
+
+### `config.testRunner` [string]
+(default: `./jasmineTestRunner/jasmineTestRunner`)
+
+Allows overriding the default jasmine test runner with the bundled jasmine 2.2 test runner: `./jasmineTestRunner/jasmine2TestRunner`.
 
 ### `config.unmockedModulePathPatterns` [array<string>]
 (default: `[]`)

--- a/src/jasmineTestRunner/__tests__/JasmineReporter-test.js
+++ b/src/jasmineTestRunner/__tests__/JasmineReporter-test.js
@@ -41,6 +41,8 @@ describe('JasmineReporter', function() {
                             {
                               actual: actualResult,
                               expected: expectedResult,
+                              message: '',
+                              isNot: false,
                               matcherName: 'toBe',
                               passed: function() { return passed; },
                               trace: {},

--- a/src/jasmineTestRunner/jasmine2TestRunner.js
+++ b/src/jasmineTestRunner/jasmine2TestRunner.js
@@ -58,7 +58,6 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
 
             return {
               pass: actual.mock.calls.length !== 0,
-              message: ''
             };
           }
         };
@@ -93,26 +92,14 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
             var calls = actual.mock.calls;
             var args = Array.prototype.slice.call(arguments, 1);
 
-            // Often toBeCalledWith is called on a mock that only has one call,
-            // so we can give a better error message in this case.
-            if (calls.length === 1) {
+            var passed = calls.some(function(call) {
+              return util.equals(call, args);
+            }, this);
 
-              return {
-                pass: util.equals(calls[0], args)
-              };
+            return {
+              pass: passed,
+            };
 
-            } else {
-
-              var passed = calls.some(function(call) {
-                return util.equals(call, args);
-              }, this);
-
-              return {
-                pass: passed,
-                message: ''
-              };
-
-            }
           }
         };
       }

--- a/src/jasmineTestRunner/jasmine2TestRunner.js
+++ b/src/jasmineTestRunner/jasmine2TestRunner.js
@@ -77,8 +77,6 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
 
             return {
               pass: util.equals(calls[calls.length - 1], args),
-              message: 'Actual: ' + jasmine.pp(calls[calls.length - 1])
-                       + ', expected: ' + jasmine.pp(args)
             };
 
           }
@@ -100,9 +98,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
             if (calls.length === 1) {
 
               return {
-                pass: util.equals(calls[0], args),
-                message: 'Actual: ' + jasmine.pp(calls[0])
-                       + ', expected: ' + jasmine.pp(args)
+                pass: util.equals(calls[0], args)
               };
 
             } else {

--- a/src/jasmineTestRunner/jasmineFormatter.js
+++ b/src/jasmineTestRunner/jasmineFormatter.js
@@ -192,7 +192,7 @@ JasmineFormatter.prototype.cleanStackTrace = function(stackTrace) {
   return stackTrace.split('\n').filter(function(line) {
 
     return keepFirstLines() ||
-          !/jest\/(vendor|src|node_modules)\//.test(line);
+          !/jest(-cli)?\/(vendor|src|node_modules)\//.test(line);
 
   }).join('\n');
 


### PR DESCRIPTION
Last few changes:
- Fix error formatting behaviour around result.isNot, which is not available in jasmine 2.
- Clean stack traces (especially necessary for jasmine 2).
- Documentation for config.testRunner option.

I also tested this version against React's suite. Some search-and-replace to fix spy and toThrow changes, but a few tests are failing on the comparison of large/deeply nested objects. This is likely a jasmine change and not related to our jest work.

---
### Upgrading to Jasmine 2
1.  Change the [`config.testRunner`](http://facebook.github.io/jest/docs/api.html#config-testrunner-string) value to `./jasmineTestRunner/jasmine2TestRunner`.
2.  Instead of `describe.only` and `it.only` use `fdescribe` and `fit`.
3. `pit` is still available, but you can also use jasmine 2's `function(done)` for asynchronous testing.

The jasmine 2.2 [upgrade guide](http://jasmine.github.io/2.2/upgrading.html) has an brief overview of the changes. The jasmine 2.0 [release notes](https://github.com/jasmine/jasmine/blob/master/release_notes/20.md) explain more internal api changes from 1.3.

---

Unresolved issue:
- Looking at complete stack traces, you see Jasmine 2 failures coming back from FakeTimers.js instead of Node's process._tickCallback. Seeing as Jasmine should be set up in an environment with real timers, this seems like an unintended change.
